### PR TITLE
Add log error and stacktrace strategy

### DIFF
--- a/deprecation_helper.gemspec
+++ b/deprecation_helper.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'deprecation_helper'
-  spec.version       = '0.1.1'
+  spec.version       = '0.2.0'
   spec.authors       = ['Alex Evanczuk']
   spec.email         = ['alex.evanczuk@gusto.com']
 

--- a/lib/deprecation_helper.rb
+++ b/lib/deprecation_helper.rb
@@ -10,6 +10,7 @@ require 'deprecation_helper/strategies/base_strategy_interface'
 require 'deprecation_helper/strategies/error_strategy_interface'
 require 'deprecation_helper/strategies/raise_error'
 require 'deprecation_helper/strategies/log_error'
+require 'deprecation_helper/strategies/log_error_and_stacktrace'
 
 require 'deprecation_helper/deprecation_exception'
 

--- a/lib/deprecation_helper/strategies/log_error_and_stacktrace.rb
+++ b/lib/deprecation_helper/strategies/log_error_and_stacktrace.rb
@@ -2,7 +2,7 @@
 
 module DeprecationHelper
   module Strategies
-    class LogError
+    class LogErrorAndStacktrace
       include BaseStrategyInterface
 
       extend T::Sig
@@ -14,7 +14,7 @@ module DeprecationHelper
 
       sig { override.params(message: String, backtrace: T::Array[String]).void }
       def apply!(message, backtrace) # rubocop:disable Lint/UnusedMethodArgument
-        @logger.warn(message)
+        @logger.warn({ message: message, backtrace: backtrace})
       end
     end
   end

--- a/spec/deprecation_helper_spec.rb
+++ b/spec/deprecation_helper_spec.rb
@@ -110,6 +110,23 @@ RSpec.describe DeprecationHelper do
       end
     end
 
+    context 'configured to do log both error and stacktrace' do
+      before do
+        DeprecationHelper.configure do |config|
+          config.deprecation_strategies = [DeprecationHelper::Strategies::LogErrorAndStacktrace.new]
+        end
+      end
+
+      context 'logger is not set' do
+        it_behaves_like 'it does not raise an error'
+
+        it 'logs an error' do
+          expect(logger).to receive(:warn).with({ message: 'This thing is deprecated', backtrace: ['frame0', 'frame1', 'frame2', 'some_special_complicated_frame']})
+          subject
+        end
+      end
+    end
+
     context 'configured for multiple purposes' do
       let(:logger) { Logger.new(STDOUT) }
 


### PR DESCRIPTION
This will allow users to more easily build allow lists by using this strategy to log out the stack trace to be analyzed for their allow list.

More context here: https://github.com/Gusto/hawaiian-ice/pull/18726/files