### PR TITLE
Loosen logger's typing to allow different loggers

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,37 +1,37 @@
-FROM ruby:2.7.2
+FROM ruby:3.2.2
 
 # Setup the buildkite-agent user/group
 RUN groupadd -r buildkite-agent && \
       useradd -u 9999 -r -g buildkite-agent buildkite-agent && \
       mkdir -p /home/buildkite-agent
- 
+
 # Setup the work directory where the application will live
 ENV APP_HOME /var/www
 WORKDIR $APP_HOME
- 
+
 # Setup bundler options to install gems in the work directory and use our gem mirror
 RUN gem install bundler && \
       bundle config --local app_config /usr/local/bundle/config && \
       bundle config --local path vendor/bundle && \
       bundle config --local "mirror.https://rubygems.org" "https://gemstash.zp-int.com" && \
       mkdir /home/buildkite-agent/.gem # This is needed for publishing gems from inside your container
- 
+
 # RAILS APP: Add Gemfile and Gemfile.lock to the work directory
 COPY Gemfile* $APP_HOME/
- 
+
 # LIBRARY: Add Gemfile, Gemfile.lock, and gemspec to the work directory
 COPY Gemfile* deprecation_helper.gemspec $APP_HOME/
- 
+
 # Run bundle install with minimal dependencies
 RUN bundle install
- 
+
 # Add the rest of the source, now that dependencies are installed
 COPY . $APP_HOME
- 
+
 # Change the owner of the relevant directories to the buildkite-agent
 RUN chown -R buildkite-agent:buildkite-agent /home/buildkite-agent && \
       chown -R buildkite-agent:buildkite-agent $APP_HOME && \
       chown -R buildkite-agent:buildkite-agent /usr/local/bundle/config
- 
+
 # Setup the container to run as the buildkite-agent user
 USER buildkite-agent

--- a/deprecation_helper.gemspec
+++ b/deprecation_helper.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'deprecation_helper'
-  spec.version       = '0.2.0'
+  spec.version       = '0.3.0'
   spec.authors       = ['Alex Evanczuk']
   spec.email         = ['alex.evanczuk@gusto.com']
 

--- a/lib/deprecation_helper/strategies/log_error.rb
+++ b/lib/deprecation_helper/strategies/log_error.rb
@@ -7,9 +7,9 @@ module DeprecationHelper
 
       extend T::Sig
 
-      sig { params(logger: T.nilable(Logger)).void }
+      sig { params(logger: T.untyped).void }
       def initialize(logger: nil)
-        @logger = T.let(logger || Logger.new(STDOUT), Logger)
+        @logger = T.let(logger || Logger.new(STDOUT), T.untyped)
       end
 
       sig { override.params(message: String, backtrace: T::Array[String]).void }

--- a/lib/deprecation_helper/strategies/log_error_and_stacktrace.rb
+++ b/lib/deprecation_helper/strategies/log_error_and_stacktrace.rb
@@ -7,9 +7,9 @@ module DeprecationHelper
 
       extend T::Sig
 
-      sig { params(logger: T.nilable(Logger)).void }
+      sig { params(logger: T.untyped).void }
       def initialize(logger: nil)
-        @logger = T.let(logger || Logger.new(STDOUT), Logger)
+        @logger = T.let(logger || Logger.new(STDOUT), T.untyped)
       end
 
       sig { override.params(message: String, backtrace: T::Array[String]).void }


### PR DESCRIPTION
- Logger doesn't have to stick with `Logger` class, it can be any class that implements logger pattern
- In Rails 7.1, `Rails.logger` swapped to `ActiveSupport::BroadcastLogger`, this breaks most of the usage of this gem in all rails projects and should be fixed by untyped the `logger` param